### PR TITLE
Fix devision by zero

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -58,7 +58,10 @@ class AccountMove(models.Model):
             if float_is_zero(total_amount, precision_rounding=move.currency_id.rounding):
                 move.matched_percentage = 1.0
             else:
-                move.matched_percentage = total_reconciled / total_amount
+                try:
+                    move.matched_percentage = total_reconciled / total_amount
+                except:
+                    move.matched_percentage = 0.0
 
     @api.one
     @api.depends('company_id')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
when total_amount is zero an exception is raised because, can't divide by zero
Desired behavior after PR is merged:
shouldn't raise the exception even if total_amount is zero


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
