### PR TITLE
comment domain for partners in bank reconciliation form

### DIFF
--- a/addons/account/static/src/js/account_reconciliation_widgets.js
+++ b/addons/account/static/src/js/account_reconciliation_widgets.js
@@ -1755,7 +1755,7 @@ var bankStatementReconciliationLine = abstractReconciliationLine.extend({
             relation: "res.partner",
             string: _t("Partner"),
             type: "many2one",
-            domain: [['parent_id','=',false], '|', ['customer','=',true], ['supplier','=',true]],
+            //domain: [['parent_id','=',false], '|', ['customer','=',true], ['supplier','=',true]],
             help: "",
             readonly: false,
             required: true,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
In bank reconciliation, we can see only companies. We want to see partners also ( we changed commercial partner computation for that purpose)
Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
